### PR TITLE
fix: unexpected IP registration in Nacos caused by NICs' ordering

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -224,8 +224,8 @@ services:
       ACTIVE: prod
       SERVICE: user
     networks:
-      outside: # user-service needs to connect to the SMTP server
       inside:
+      outside: # user-service needs to connect to the SMTP server
     deploy:
       resources:
         limits:


### PR DESCRIPTION
修改前user服务注册到nacos的ip是outside虚拟网卡的ip，导致gateway服务无法访问到user服务